### PR TITLE
switched to iso 8601

### DIFF
--- a/spec.yml
+++ b/spec.yml
@@ -45,16 +45,16 @@ paths:
           schema:
             type: string
             format: datetime
-            description: Time in RFC 3339 format
-            example: "2018-06-10T10:11:46.8328983+02:00"
+            description: Time in ISO 8601 format
+            example: "2007-08-31T16:47+00:00"
         - name: received_after
           in: query
           description: Filter for received date
           schema:
             type: string
             format: datetime
-            description: Time in RFC 3339 format
-            example: "2018-06-10T10:11:46.8328983+02:00"
+            description: Time in ISO 8601 format
+            example: "2007-08-31T16:47+00:00"
         - name: mail_from
           in: query
           description: Filter for mail sender
@@ -146,8 +146,8 @@ components:
         received:
           type: string
           format: datetime
-          description: Time in RFC 3339 format
-          example: "2018-06-10T10:11:46.8328983+02:00"
+          description: Time in ISO 8601 format
+          example: "2007-08-31T16:47+00:00"
         received_from:
           type: string
           description: Server mail received from


### PR DESCRIPTION
Change time format for better compatibility with default Python time format: ISO 8601.